### PR TITLE
mrac2mu updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ where `<DICOM file>` is the input file for extraction, `<OUTPUTDIR>` is the targ
 #### Usage: 
 
 ```bash
-nm_mrac2mu -i <DICOMDIR> -o <OUTPUT file>
+nm_mrac2mu -i <DICOMDIR> -o <OUTPUT file> [--orient <ORIENTATION> --head]
 ```
 
-where `<DICOMDIR>` is the path to the MRAC DICOM folder and `<OUTPUT file>` is the destination file.
+where `<DICOMDIR>` is the path to the MRAC DICOM folder and `<OUTPUT file>` is the destination file. `<ORIENTATION>` is the desired coordinate orientation (default 'RAS'). The switch `--head` will generate a mu-map in 344x344x127 matrix and is currently hard-coded for the mMR brain MRAC.
 
 #### Output extensions
 

--- a/lib/nmtools/MRAC.hpp
+++ b/lib/nmtools/MRAC.hpp
@@ -497,7 +497,7 @@ bool MRAC2MU::GetStudyTime(std::string &studyTime){
   return true;
 }
 
-itk::SpatialOrientation::CoordinateTerms GetOrientationCode(char c){
+itk::SpatialOrientation::CoordinateTerms GetOrientationCode(char &c){
 
   c = toupper(c);
 
@@ -530,7 +530,7 @@ itk::SpatialOrientation::CoordinateTerms GetOrientationCode(char c){
 
 };
 
-bool MRAC2MU::SetDesiredCoordinateOrientation(const std::string orient){ 
+bool MRAC2MU::SetDesiredCoordinateOrientation(std::string orient){ 
 
   std::vector<int> coordVals(3);
 

--- a/lib/nmtools/MRAC.hpp
+++ b/lib/nmtools/MRAC.hpp
@@ -89,7 +89,7 @@ public:
   void SetParams(nlohmann::json params);
 
   //Set output orientation
-  bool SetDesiredCoordinateOrientation(const std::string orient);
+  bool SetDesiredCoordinateOrientation(const std::string &target);
 
   void SetIsHead(bool bStatus){ _isHead = bStatus; };
 
@@ -306,7 +306,7 @@ bool MRAC2MU::Read(){
     //Execute pipeline
     dicomReader->Update();
 
-    //Orient to LPS
+    //Re-orient
     typedef typename itk::OrientImageFilter<MuMapImageType,MuMapImageType> OrienterType;
     typename OrienterType::Pointer orienter = OrienterType::New();
   
@@ -530,10 +530,11 @@ itk::SpatialOrientation::CoordinateTerms GetOrientationCode(char &c){
 
 };
 
-bool MRAC2MU::SetDesiredCoordinateOrientation(std::string orient){ 
+bool MRAC2MU::SetDesiredCoordinateOrientation(const std::string &target){ 
 
   std::vector<int> coordVals(3);
 
+  std::string orient = target;
   //Check we have three letter code.
   if (orient.size() != 3){
     LOG(ERROR) << "Expected three letter orientation code. Read: " << orient;

--- a/src/NMmrac2mu.cpp
+++ b/src/NMmrac2mu.cpp
@@ -49,7 +49,8 @@ int main(int argc, char **argv)
     //("verbose,v", "Be verbose")
     ("input,i", po::value<std::string>(&inputDirPath)->required(), "Input directory")
     ("output,o", po::value<std::string>(&outputFilePath)->required(), "Output file")
-    ("orient", po::value<std::string>(&coordOrientation), "Output orientation: RAI, RAS or LPS")
+    ("orient", po::value<std::string>(&coordOrientation), "Output orientation: e.g. RAI or LPS (default = RAI)")
+    ("head", "Output mu-map for mMR brain")
     ("log,l", "Write log file");
 
   //Evaluate command line options
@@ -126,12 +127,14 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
   }
 
-  //mrac->SetDesiredCoordinateOrientation(coordOrientation);
+  if (vm.count("head")){
+    mrac->SetIsHead(true);
+  }
  
   if (mrac->Update()){
-    LOG(INFO) << "Scaling and reslicing complete";
+    LOG(INFO) << "Scaling complete";
   } else {
-    LOG(ERROR) << "Failed to scale and reslice";
+    LOG(ERROR) << "Failed to scale image";
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
### `nm_mrac2mu` 

- Allows user to specify the coordinate orientation from the command line using:
`--orient <ORDER>`, where `<ORDER>` is a three character code e.g. `RAI` or `LPS`. Should help with #11.

- Reslicing is turned off by default. If the user passes the switch `--head` the image will be resampled into a `344x344x127` matrix which assumes the input is a mMR brain MRAC. This is currently hard-coded, but the default addresses #8.



